### PR TITLE
fix: add CreatedAt field to MarzneshinUser to avoid validation error

### DIFF
--- a/source/marzneshin.go
+++ b/source/marzneshin.go
@@ -36,6 +36,7 @@ type MarzneshinUser struct {
 	DataLimitReached       bool    `json:"data_limit_reached"`
 	Enabled                bool    `json:"enabled"`
 	SubscriptionURL        string  `json:"subscription_url"`
+	CreatedAt              string  `json:"created_at"`
 }
 
 type MarzneshinUsersResponse struct {
@@ -145,6 +146,7 @@ func (p *MarzneshinPanel) GetUsers(offset, limit int) (*models.UsersResponse, er
 			SubscriptionHash:       user.Key,
 			DataLimitResetStrategy: strings.ToUpper(user.DataLimitResetStrategy),
 			Note:                   getStringValue(user.Note),
+			CreatedAt:              user.CreatedAt,
 		}
 
 		if user.ExpireDate != nil {


### PR DESCRIPTION
During migration, user creation could fail with the following error:
```
Failed to create user 12345678: creating user failed: status 400, body: {
  "statusCode":400,
  "message":"Validation failed",
  "errors":[
    {
      "code":"invalid_string",
      "validation":"datetime",
      "message":"Invalid date format",
      "path":["createdAt"]
    }
  ]
}
```
The error occurred because the createdAt field was missing (null) when attempting to create a new user.

### Solution
- Added the CreatedAt field to MarzneshinUser
- Ensured that ProcessedUser now receives a valid createdAt value